### PR TITLE
Remove horizontal scroll from broccoli animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,9 @@
     :root {
       color-scheme: light dark;
     }
+    html {
+      overflow-x: hidden;
+    }
     * {
       box-sizing: border-box;
     }
@@ -21,6 +24,7 @@
       font-family: "Courier New", Courier, monospace;
       background: radial-gradient(circle at top, #f1ffe3 0%, #d6ffb7 45%, #e9ffe6 100%);
       color: #1e2a1d;
+      overflow-x: hidden;
     }
     main {
       width: min(60ch, 100%);
@@ -36,12 +40,12 @@
       max-width: 30ch;
     }
     pre {
-      margin: 0;
+      margin: 0 auto;
       width: min(100%, 44ch);
       font-size: clamp(0.75rem, 2.1vw, 1.1rem);
       line-height: 1.35;
       white-space: pre;
-      overflow-x: auto;
+      overflow-x: hidden;
       background: rgba(255, 255, 255, 0.9);
       border: 2px dashed #4caf50;
       padding: clamp(1rem, 4vw, 2.25rem);


### PR DESCRIPTION
## Summary
- hide horizontal overflow on the page so the animation never triggers a scrollbar
- center the ASCII block with `margin: 0 auto` instead of relying on extra leading spaces
- keep the slimmer animation frames introduced earlier

## Testing
- opened `index.html` locally at wide and small breakpoints to confirm no horizontal scrollbar while the broccoli loop still plays